### PR TITLE
Fixed build errors for "mvn install" and "mvn deploy"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@
 						</configuration>
 					</execution>
 					<!-- Capture secondary private javadoc -->
+					<!--
 					<execution>
 						<id>add-private-javadoc</id>
 						<phase>package</phase>
@@ -149,6 +150,7 @@
 							</artifacts>
 						</configuration>
 					</execution>
+					-->
 					<execution>
 						<id>add-source</id>
 						<phase>generate-sources</phase>


### PR DESCRIPTION
Commented out a section of code that appeared to be a placeholder anyway, which was causing errors while running "mvn install" or "mvn deploy" (this is necessary if we want to deploy ldapchai to maven central).

@jrivard Please review and merge
