### PR TITLE
Disables DocLint when compiling on Java 1.8 and higher.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
 								</goals>
 								<configuration>
 									<show>private</show>
-									<additionalparam>-Xdoclint:none</additionalparam>
+									<additionalparam>${javadoc.opts}</additionalparam>
 									<outputDirectory>${outputDirectory.private}/apidocs</outputDirectory>
 									<jarOutputDirectory>${outputDirectory.private}</jarOutputDirectory>
 									<attach>false</attach> <!-- requires using helper to attach with alternate classifier -->
@@ -265,7 +265,7 @@
 								</goals>
 								<configuration>
 									<show>public</show>
-									<additionalparam>-Xdoclint:none</additionalparam>
+									<additionalparam>${javadoc.opts}</additionalparam>
 									<excludePackageNames>com.novell.security:com.novell.ldapchai.schema:com.novell.ldapchai.cr.nmasAuth:com.novell.ldapchai.util.internal:com.novell.ldapchai.impl.*</excludePackageNames>
 									<!-- <outputDirectory>${project.build.directory}/apidocs</outputDirectory>
 										default -->
@@ -275,6 +275,16 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		
+		<profile>
+			<id>doclint-java8-disable</id>
+			<activation>
+				<jdk>[1.8,)</jdk>
+			</activation>
+			<properties>
+				<javadoc.opts>-Xdoclint:none</javadoc.opts>
+			</properties>
 		</profile>
 
 		<profile>


### PR DESCRIPTION
DocLint is a new feature in Java 1.8, which provides a more strict checking of JavaDoc syntax.  Since we have a bunch of JavaDoc comments that aren't 100% in compliance with the strict syntax, we get DocLint build errors when we build on Java 1.8+.  By adding the flag: "-Xdoclint:none", we disable DocLint for Java 1.8.  However, since Java 1.7 and lower don't recognize this flag, we had to put the flag in a maven profile so it's not used when Java 1.7 and lower are detected.

@jrivard Please review and merge.