### PR TITLE
Bumped the revision number, since ldapchai-0.6.6 was deployed to maven central.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<groupId>com.github.ldapchai</groupId>
-	<version>0.6.6-SNAPSHOT</version>
+	<version>0.6.7-SNAPSHOT</version>
 	<artifactId>ldapchai</artifactId>
 	<packaging>jar</packaging>
 


### PR DESCRIPTION
Bumped the revision number, since ldapchai-0.6.6 was deployed to maven central.
See: https://repo.maven.apache.org/maven2/com/github/ldapchai/ldapchai/0.6.6/

@jrivard Please review and merge