### PR TITLE
Update AbstractChaiEntry to return null for 0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,11 @@
 		LDAP Chai has methods for commonly used functions, and relieves developers of the need to write code that has been written many times before.
 	</description>
 	<url>https://github.com/ldapchai/ldapchai</url>
-	
+
 	<properties>
 		<maven.compiler.source>1.5</maven.compiler.source>
 		<maven.compiler.target>1.5</maven.compiler.target>
-		<skipTests>true</skipTests>  <!-- missing test configuration from source? -->
+		<skipTests>false</skipTests>
 		<outputDirectory.private>${project.build.directory}/private</outputDirectory.private>
 		<timestamp.iso>${maven.build.timestamp}</timestamp.iso>
 		<maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>
@@ -73,6 +73,12 @@
 			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>1.10.19</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -86,16 +92,12 @@
 				<targetPath>src</targetPath>
 			</resource>
 		</resources>
-		<!--<testSourceDirectory>tests</testSourceDirectory>-->
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.16</version>
 				<configuration>
-					<!-- <parallel>classes</parallel> -->
-					<includes>
-						<include>**/*Tester.java</include>
-					</includes>
+					<skipTests>${skipTests}</skipTests>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/com/novell/ldapchai/impl/AbstractChaiEntry.java
+++ b/src/main/java/com/novell/ldapchai/impl/AbstractChaiEntry.java
@@ -412,7 +412,7 @@ public abstract class AbstractChaiEntry implements ChaiEntry {
             throws ChaiUnavailableException, ChaiOperationException
     {
         final String value = this.readStringAttribute(attributeName);
-        if (value != null) {
+        if (value != null && !value.equalsIgnoreCase("0")) {
             return EdirEntries.convertZuluToDate(value);
         }
         return null;

--- a/src/main/java/com/novell/ldapchai/impl/edir/entry/EdirEntries.java
+++ b/src/main/java/com/novell/ldapchai/impl/edir/entry/EdirEntries.java
@@ -99,7 +99,7 @@ public class EdirEntries {
      * Convert the commonly used eDirectory zulu time string to java Date object.
      * See the <a href="http://developer.novell.com/documentation/ndslib/schm_enu/data/sdk5701.html">eDirectory Time attribute syntax definition</a> for more details.
      *
-     * @param dateString a date string in the format of "yyyyMMddHHmmss'Z'", for example "199412161032Z"
+     * @param dateString a date string in the format of "yyyyMMddHHmmss'Z'", for example "19941216103200Z"
      * @return A Date object representing the string date
      * @throws IllegalArgumentException if dateString is incorrectly formatted
      */
@@ -126,6 +126,7 @@ public class EdirEntries {
         cal.set(Calendar.HOUR_OF_DAY, Integer.parseInt(dateString.substring(8, 10)));
         cal.set(Calendar.MINUTE, Integer.parseInt(dateString.substring(10, 12)));
         cal.set(Calendar.SECOND, Integer.parseInt(dateString.substring(12, 14)));
+        cal.set(Calendar.MILLISECOND, 0);
 
         return cal.getTime();
     }

--- a/src/test/java/com/novell/ldapchai/impl/AbstractChaiEntryTest.java
+++ b/src/test/java/com/novell/ldapchai/impl/AbstractChaiEntryTest.java
@@ -1,0 +1,68 @@
+package com.novell.ldapchai.impl;
+
+import com.novell.ldapchai.provider.ChaiProvider;
+import org.hamcrest.core.IsNull;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+
+public class AbstractChaiEntryTest {
+
+    private AbstractChaiEntryMakeReal classUnderTest;
+    private ChaiProvider mockChiProvider;
+    private static String ANY_DN = "testdn";
+    private static String ANY_DATE_VALUE = "dateKey";
+
+    @Before
+    public void setup() {
+        mockChiProvider = mock(ChaiProvider.class);
+        classUnderTest =  new AbstractChaiEntryMakeReal("testdn", mockChiProvider);
+    }
+
+    @Test
+    public void shouldReturnNullWhenReadDateAttributeRetrievesValueNull() throws Exception {
+        when(mockChiProvider.readStringAttribute(ANY_DN, ANY_DATE_VALUE)).thenReturn(null);
+        assertThat(classUnderTest.readDateAttribute(ANY_DATE_VALUE), is(IsNull.nullValue()));
+    }
+
+    @Test
+    public void shouldReturnNullWhenReadDateAttributeRetrievesValue0() throws Exception {
+        when(mockChiProvider.readStringAttribute(ANY_DN, ANY_DATE_VALUE)).thenReturn("0");
+        assertThat(classUnderTest.readDateAttribute(ANY_DATE_VALUE), is(IsNull.nullValue()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldReturnExceptionWhenReadDateAttributeValueIsToShort() throws Exception {
+        when(mockChiProvider.readStringAttribute(ANY_DN, ANY_DATE_VALUE)).thenReturn("01234567890123");
+        try {
+            classUnderTest.readDateAttribute(ANY_DATE_VALUE);
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), is("zulu date too short"));
+            throw e;
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldReturnExceptionWhenReadDateAttributeValueDoesNotHaveZAtChar14() throws Exception {
+        when(mockChiProvider.readStringAttribute(ANY_DN, ANY_DATE_VALUE)).thenReturn("0123456789012345");
+        try {
+            classUnderTest.readDateAttribute(ANY_DATE_VALUE);
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), is("zulu date must end in 'Z'"));
+            throw e;
+        }
+    }
+
+    public class AbstractChaiEntryMakeReal extends  AbstractChaiEntry {
+
+        public AbstractChaiEntryMakeReal(final String entryDN, final ChaiProvider chaiProvider) {
+            super(entryDN, chaiProvider);
+        }
+    }
+}

--- a/src/test/java/com/novell/ldapchai/impl/edir/entry/EdirEntriesTest.java
+++ b/src/test/java/com/novell/ldapchai/impl/edir/entry/EdirEntriesTest.java
@@ -1,0 +1,56 @@
+package com.novell.ldapchai.impl.edir.entry;
+
+
+import org.hamcrest.core.IsNull;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class EdirEntriesTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldReturnExceptionWhenConvertZuluToDateValueIsToShort() throws Exception {
+
+        try {
+            EdirEntries.convertZuluToDate("01234567890123");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), is("zulu date too short"));
+            throw e;
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldReturnExceptionWhenConvertZuluToDateValueDoesNotHaveZAtChar14() throws Exception {
+        try {
+            EdirEntries.convertZuluToDate("012345678901234");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), is("zulu date must end in 'Z'"));
+            throw e;
+        }
+    }
+
+    @Test
+    public void shouldReturnExceptionWhenConvertZuluToDateValueDoesHaveZAtChar14ButIsLonger() throws Exception {
+        Date d = EdirEntries.convertZuluToDate("20150101000000Z9");
+        assertThat(d.getTime(), is(1420070400000L));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldReturnExceptionWhenConvertZuluToDateValueIsNull() throws Exception {
+        try {
+            EdirEntries.convertZuluToDate(null);
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage(), is(IsNull.nullValue()));
+            throw e;
+        }
+    }
+
+    @Test
+    public void shouldReturnDateWhenConvertZuluToDateValueIsCorrect() throws Exception {
+        Date d = EdirEntries.convertZuluToDate("20150402010745Z");
+        assertThat(d.getTime(), is(1427936865000L));
+    }
+}


### PR DESCRIPTION
OpenDJ for some reason will save in the PWM passwordLastUpdateAttribute a 0
instead of leaving it null or empty string. When PWM tries to read a record
which has this value set, the help desk user or administrator has an error
displayed and the user logged out.

This also includes extra tests surrounding the date format string including:
  * update comments for what a valid string is
  * include extra exception handling tests for EdirEntries
  * test for value is 0 and return null
  * update .gitignore for Intellij files to not be included
  * allow maven run the default maven test package since no tests were
    being run anyway