### PR TITLE
Add support for adding OpenLDAP users to groups and additional password policy logging

### DIFF
--- a/examples/ReadUserData.java
+++ b/examples/ReadUserData.java
@@ -74,7 +74,7 @@ public class ReadUserData {
             // Read the user's group membership, and output each group DN.
             System.out.println(user.getEntryDN() + " groups: ");
             for (ChaiGroup group : user.getGroups()) {
-                System.out.print(group.getEntryDN());
+                System.out.println(group.getEntryDN());
             }
             System.out.println("");
 

--- a/src/main/java/com/novell/ldapchai/ChaiConstant.java
+++ b/src/main/java/com/novell/ldapchai/ChaiConstant.java
@@ -219,7 +219,12 @@ public interface ChaiConstant {
     public static final String ATTR_LDAP_MEMBER = "member";
 
     /**
-     * Attribute name to define the Security Equivalnce.
+     * Attribute name to define the User Member Of.
+     */
+    public static final String ATTR_LDAP_MEMBER_OF = "memberOf";
+
+    /**
+     * Attribute name to define the Security Equivalence.
      */
     public static final String ATTR_LDAP_EQUIVALENT_TO_ME = "equivalentToMe";
 

--- a/src/main/java/com/novell/ldapchai/impl/AbstractChaiUser.java
+++ b/src/main/java/com/novell/ldapchai/impl/AbstractChaiUser.java
@@ -78,7 +78,7 @@ public abstract class AbstractChaiUser extends AbstractChaiEntry implements Chai
         return Collections.unmodifiableSet(reports);
     }
 
-    public final Set<ChaiGroup> getGroups()
+    public Set<ChaiGroup> getGroups()
             throws ChaiOperationException, ChaiUnavailableException
     {
         final Set<ChaiGroup> returnGroups = new HashSet<ChaiGroup>();

--- a/src/main/java/com/novell/ldapchai/impl/AbstractChaiUser.java
+++ b/src/main/java/com/novell/ldapchai/impl/AbstractChaiUser.java
@@ -141,6 +141,7 @@ public abstract class AbstractChaiUser extends AbstractChaiEntry implements Chai
     public void setPassword(final String newPassword)
             throws ChaiUnavailableException, ChaiPasswordPolicyException, ChaiOperationException
     {
+        LOGGER.trace("newPassword = " + newPassword);
         this.setPassword(newPassword, false);
     }
 

--- a/src/main/java/com/novell/ldapchai/impl/AbstractChaiUser.java
+++ b/src/main/java/com/novell/ldapchai/impl/AbstractChaiUser.java
@@ -141,7 +141,6 @@ public abstract class AbstractChaiUser extends AbstractChaiEntry implements Chai
     public void setPassword(final String newPassword)
             throws ChaiUnavailableException, ChaiPasswordPolicyException, ChaiOperationException
     {
-        LOGGER.trace("newPassword = " + newPassword);
         this.setPassword(newPassword, false);
     }
 

--- a/src/main/java/com/novell/ldapchai/impl/openldap/entry/OpenLDAPEntries.java
+++ b/src/main/java/com/novell/ldapchai/impl/openldap/entry/OpenLDAPEntries.java
@@ -25,10 +25,13 @@ import com.novell.ldapchai.exception.ChaiOperationException;
 import com.novell.ldapchai.exception.ChaiUnavailableException;
 import com.novell.ldapchai.impl.edir.entry.EdirEntries;
 import com.novell.ldapchai.provider.ChaiSetting;
+import com.novell.ldapchai.util.ChaiLogger;
 
 import java.util.Date;
 
 public class OpenLDAPEntries {
+
+    private static final ChaiLogger LOGGER = ChaiLogger.getLogger(OpenLDAPEntries.class);
     
     public static Date convertZuluToDate(final String dateString)
     {
@@ -52,6 +55,7 @@ public class OpenLDAPEntries {
             if (searchEntry.isValid()) {
                 final String pwdPolicySubentryValue = searchEntry.readStringAttribute(
                         ChaiConstant.ATTR_OPENLDAP_PASSWORD_SUB_ENTRY);
+                LOGGER.trace("pwdPolicySubentryValue = " + pwdPolicySubentryValue);
                 if (pwdPolicySubentryValue != null && !pwdPolicySubentryValue.isEmpty()) {
                     final OpenLDAPEntry policyEntry = new OpenLDAPEntry(pwdPolicySubentryValue,
                             person.getChaiProvider());
@@ -68,6 +72,7 @@ public class OpenLDAPEntries {
         }
         
         final String passwordPolicyDn = person.getChaiProvider().getChaiConfiguration().getSetting(ChaiSetting.PASSWORD_POLICY_DN);
+        LOGGER.debug("passwordPolicyDn = " + passwordPolicyDn);
         if (passwordPolicyDn != null && passwordPolicyDn.trim().length() > 0) {
             final OpenLDAPPasswordPolicy defaultPolicy = new OpenLDAPPasswordPolicy(passwordPolicyDn, person.getChaiProvider());
             if (defaultPolicy.isValid()) {

--- a/src/main/java/com/novell/ldapchai/impl/openldap/entry/OpenLDAPGroup.java
+++ b/src/main/java/com/novell/ldapchai/impl/openldap/entry/OpenLDAPGroup.java
@@ -19,12 +19,24 @@
 
 package com.novell.ldapchai.impl.openldap.entry;
 
+import com.novell.ldapchai.ChaiConstant;
 import com.novell.ldapchai.ChaiGroup;
+import com.novell.ldapchai.ChaiUser;
+import com.novell.ldapchai.exception.ChaiOperationException;
+import com.novell.ldapchai.exception.ChaiUnavailableException;
 import com.novell.ldapchai.impl.AbstractChaiGroup;
 import com.novell.ldapchai.provider.ChaiProvider;
 
 class OpenLDAPGroup extends AbstractChaiGroup implements ChaiGroup {
     public OpenLDAPGroup(final String groupDN, final ChaiProvider chaiProvider) {
         super(groupDN, chaiProvider);
+    }
+
+    public void addMember(final ChaiUser theUser) throws ChaiUnavailableException, ChaiOperationException {
+        this.addAttribute(ChaiConstant.ATTR_LDAP_MEMBER, theUser.getEntryDN());
+    }
+
+    public void removeMember(final ChaiUser theUser) throws ChaiUnavailableException, ChaiOperationException {
+        this.deleteAttribute(ChaiConstant.ATTR_LDAP_MEMBER, theUser.getEntryDN());
     }
 }

--- a/src/main/java/com/novell/ldapchai/impl/openldap/entry/OpenLDAPPasswordPolicy.java
+++ b/src/main/java/com/novell/ldapchai/impl/openldap/entry/OpenLDAPPasswordPolicy.java
@@ -279,7 +279,7 @@ public class OpenLDAPPasswordPolicy extends OpenLDAPEntry implements ChaiPasswor
             return (Map) properties;
         }
         catch (IOException e) {
-            LOGGER.trace("Error opening checkpassword.conf", e);
+            LOGGER.trace("Error opening " + CHECK_PASSWORD_CONFIGURATION, e);
         }
         finally {
             if (reader != null) {

--- a/src/main/java/com/novell/ldapchai/impl/openldap/entry/OpenLDAPPasswordPolicy.java
+++ b/src/main/java/com/novell/ldapchai/impl/openldap/entry/OpenLDAPPasswordPolicy.java
@@ -258,11 +258,15 @@ public class OpenLDAPPasswordPolicy extends OpenLDAPEntry implements ChaiPasswor
 
         // read all attribute values from entry.
         allEntryValues.putAll(readStringAttributes(LDAP_PASSWORD_ATTRIBUTES));
+        LOGGER.trace("allEntryValues = " + allEntryValues);
         String pwdCheckQuality = allEntryValues.get(ChaiConstant.ATTR_OPENLDAP_PASSWORD_POLICY_CHECK_QUALITY);
+        LOGGER.debug("pwdCheckQuality = " + pwdCheckQuality);
         if (pwdCheckQuality != null && ("1".equals(pwdCheckQuality) || "2".equals(pwdCheckQuality))) {
             allEntryValues.putAll(readCheckPasswordAttributes());
         }
+        LOGGER.trace("allEntryValues = " + allEntryValues);
         ruleMap.putAll(createRuleMapUsingAttributeValues(allEntryValues));
+        LOGGER.trace("ruleMap = " + ruleMap);
     }
     
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -275,7 +279,7 @@ public class OpenLDAPPasswordPolicy extends OpenLDAPEntry implements ChaiPasswor
             return (Map) properties;
         }
         catch (IOException e) {
-            // ignore
+            LOGGER.trace("Error opening checkpassword.conf", e);
         }
         finally {
             if (reader != null) {
@@ -305,6 +309,7 @@ public class OpenLDAPPasswordPolicy extends OpenLDAPEntry implements ChaiPasswor
             if (attribute != null) {
                 returnMap.put(rule.getKey(), attribute.getDefaultValue());
                 final String attributeName = attribute.getLdapAttribute();
+                LOGGER.trace("attributeName = " + attributeName);
                 if (attributeName != null && entryValues != null && entryValues.containsKey(attributeName)) {
                     returnMap.put(rule.getKey(), entryValues.get(attributeName));
                 }

--- a/src/main/java/com/novell/ldapchai/impl/openldap/entry/OpenLDAPUser.java
+++ b/src/main/java/com/novell/ldapchai/impl/openldap/entry/OpenLDAPUser.java
@@ -22,6 +22,7 @@ package com.novell.ldapchai.impl.openldap.entry;
 import java.util.Date;
 
 import com.novell.ldapchai.ChaiConstant;
+import com.novell.ldapchai.ChaiGroup;
 import com.novell.ldapchai.ChaiPasswordPolicy;
 import com.novell.ldapchai.ChaiPasswordRule;
 import com.novell.ldapchai.ChaiUser;
@@ -36,6 +37,14 @@ public class OpenLDAPUser extends AbstractChaiUser implements ChaiUser
 
     public OpenLDAPUser(String userDN, ChaiProvider chaiProvider) {
         super(userDN, chaiProvider);
+    }
+
+    public void addGroupMembership(ChaiGroup theGroup) throws ChaiOperationException, ChaiUnavailableException {
+        theGroup.addAttribute(ChaiConstant.ATTR_LDAP_MEMBER, this.getEntryDN());
+    }
+
+    public void removeGroupMembership(ChaiGroup theGroup) throws ChaiOperationException, ChaiUnavailableException {
+        theGroup.deleteAttribute(ChaiConstant.ATTR_LDAP_MEMBER, this.getEntryDN());
     }
 
     @Override

--- a/src/main/java/com/novell/ldapchai/impl/openldap/entry/OpenLDAPUser.java
+++ b/src/main/java/com/novell/ldapchai/impl/openldap/entry/OpenLDAPUser.java
@@ -19,9 +19,13 @@
 
 package com.novell.ldapchai.impl.openldap.entry;
 
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 import com.novell.ldapchai.ChaiConstant;
+import com.novell.ldapchai.ChaiFactory;
 import com.novell.ldapchai.ChaiGroup;
 import com.novell.ldapchai.ChaiPasswordPolicy;
 import com.novell.ldapchai.ChaiPasswordRule;
@@ -37,6 +41,17 @@ public class OpenLDAPUser extends AbstractChaiUser implements ChaiUser
 
     public OpenLDAPUser(String userDN, ChaiProvider chaiProvider) {
         super(userDN, chaiProvider);
+    }
+
+    public Set<ChaiGroup> getGroups()
+            throws ChaiOperationException, ChaiUnavailableException
+    {
+        final Set<ChaiGroup> returnGroups = new HashSet<ChaiGroup>();
+        final Set<String> groups = this.readMultiStringAttribute(ChaiConstant.ATTR_LDAP_MEMBER_OF);
+        for (final String group : groups) {
+            returnGroups.add(ChaiFactory.createChaiGroup(group, this.getChaiProvider()));
+        }
+        return Collections.unmodifiableSet(returnGroups);
     }
 
     public void addGroupMembership(ChaiGroup theGroup) throws ChaiOperationException, ChaiUnavailableException {

--- a/src/main/java/com/novell/ldapchai/provider/JNDIProviderImpl.java
+++ b/src/main/java/com/novell/ldapchai/provider/JNDIProviderImpl.java
@@ -1149,6 +1149,7 @@ public class JNDIProviderImpl extends AbstractProvider implements ChaiProviderIm
     private void convertNamingException(final NamingException e)
             throws ChaiOperationException, ChaiUnavailableException
     {
+        LOGGER.trace(e.getMessage(), e);
         // important safety tip: naming exceptions sometimes come with null messages....
         String errorMsg = e.getClass().getName();
         if (e.getMessage() != null) {


### PR DESCRIPTION
I added support for adding OpenLDAP users to groups and retrieving the user's groups.

I also added additional DEBUG/TRACE logging for determining OpenLDAP password policy configuration errors.