### PR TITLE
Fix issue with passwordExpirationTime

### DIFF
--- a/src/main/java/com/novell/ldapchai/impl/directoryServer389/entry/DirectoryServer389User.java
+++ b/src/main/java/com/novell/ldapchai/impl/directoryServer389/entry/DirectoryServer389User.java
@@ -95,7 +95,7 @@ class DirectoryServer389User extends AbstractChaiUser implements ChaiUser {
     public void expirePassword()
             throws ChaiOperationException, ChaiUnavailableException
     {
-        this.writeStringAttribute(ATTR_PASSWORD_EXPIRE_TIME, "19700101010101Z");
+        this.writeStringAttribute(ATTR_PASSWORD_EXPIRE_TIME, "19800101010101Z");
     }
 
 }

--- a/src/main/java/com/novell/ldapchai/impl/edir/entry/InetOrgPersonImpl.java
+++ b/src/main/java/com/novell/ldapchai/impl/edir/entry/InetOrgPersonImpl.java
@@ -94,7 +94,7 @@ class InetOrgPersonImpl extends AbstractChaiUser implements InetOrgPerson, ChaiU
             writeAttribute = ChaiConstant.ATTR_LDAP_LOGIN_INTRUDER_ATTEMPTS;
             this.writeStringAttribute(ChaiConstant.ATTR_LDAP_LOGIN_INTRUDER_ATTEMPTS, "0");
             writeAttribute = ChaiConstant.ATTR_LDAP_LOGIN_INTRUDER_RESET_TIME;
-            this.writeStringAttribute(ChaiConstant.ATTR_LDAP_LOGIN_INTRUDER_RESET_TIME, "19700101010101Z");
+            this.writeStringAttribute(ChaiConstant.ATTR_LDAP_LOGIN_INTRUDER_RESET_TIME, "19800101010101Z");
 
             final String limit = this.readStringAttribute(ChaiConstant.ATTR_LDAP_LOGIN_GRACE_LIMIT);
             if (limit != null) {
@@ -253,7 +253,7 @@ class InetOrgPersonImpl extends AbstractChaiUser implements InetOrgPerson, ChaiU
     public void expirePassword()
             throws ChaiOperationException, ChaiUnavailableException
     {
-        this.writeStringAttribute(ATTR_PASSWORD_EXPIRE_TIME, "19700101010101Z");
+        this.writeStringAttribute(ATTR_PASSWORD_EXPIRE_TIME, "19800101010101Z");
     }
 
     public boolean isPasswordLocked()

--- a/src/main/java/com/novell/ldapchai/impl/oracleds/entry/InetOrgPerson.java
+++ b/src/main/java/com/novell/ldapchai/impl/oracleds/entry/InetOrgPerson.java
@@ -117,6 +117,6 @@ public class InetOrgPerson extends AbstractChaiUser implements ChaiUser {
     public void expirePassword()
             throws ChaiOperationException, ChaiUnavailableException
     {
-        this.writeStringAttribute("passwordExpirationTime", "19700101010101Z");
+        this.writeStringAttribute("passwordExpirationTime", "19800101010101Z");
     }
 }


### PR DESCRIPTION
Using PWM(SSPR) we have found that after a user triggers a password reset they are unable to change a password using a third party service implemented in PHP. This appears to be due to the choice of the password expiration time value of 19700101010101Z. Because of our timezone the value is interpreted to be prior to the epoch and this causes an error. This pull request changes the password expiration value to 1980, still well in the past, but likely to side step the epoch/timezone issue.