### PR TITLE
Added partial support for entry renaming / moving - needs review

### DIFF
--- a/src/main/java/com/novell/ldapchai/provider/AbstractProvider.java
+++ b/src/main/java/com/novell/ldapchai/provider/AbstractProvider.java
@@ -297,6 +297,23 @@ abstract class AbstractProvider implements ChaiProvider, ChaiProviderImplementor
             }
         }
 
+        public final void renameEntry(final String entryDN, final String newRDN, final String newParentDN) {
+            if ( newParentDN == null )
+            {
+                throw new NullPointerException( "newParentDN must not be null" );
+            }
+
+            if ( newRDN == null )
+            {
+                throw new NullPointerException( "newRDN must not be null" );
+            }
+
+            if ( entryDN == null )
+            {
+                throw new NullPointerException( "entryDN must not be null" );
+            }
+        }
+
         public final void deleteEntry( final String entryDN )
         {
             if ( entryDN == null )

--- a/src/main/java/com/novell/ldapchai/provider/ApacheLdapProviderImpl.java
+++ b/src/main/java/com/novell/ldapchai/provider/ApacheLdapProviderImpl.java
@@ -308,6 +308,13 @@ public class ApacheLdapProviderImpl extends AbstractProvider implements ChaiProv
         }
     }
 
+    @ChaiProvider.LdapOperation
+    @ChaiProvider.ModifyOperation
+    public void renameEntry( String entryDN, String newRDN, String newParentDN )
+            throws ChaiOperationException, ChaiUnavailableException, IllegalStateException {
+        throw ChaiOperationException.forErrorMessage( "Not implemented" );
+    }
+
     public void deleteEntry( final String entryDN )
             throws ChaiOperationException, ChaiUnavailableException, IllegalStateException
     {

--- a/src/main/java/com/novell/ldapchai/provider/ChaiProvider.java
+++ b/src/main/java/com/novell/ldapchai/provider/ChaiProvider.java
@@ -124,6 +124,11 @@ public interface ChaiProvider
     void createEntry( String entryDN, Set<String> baseObjectClasses, Map<String, String> stringAttributes )
             throws ChaiOperationException, ChaiUnavailableException, IllegalStateException;
 
+    @ChaiProvider.LdapOperation
+    @ChaiProvider.ModifyOperation
+    void renameEntry(String entryDN, String newRDN, String newParentDN)
+            throws ChaiOperationException, ChaiUnavailableException, IllegalStateException;
+
     /**
      * Delete the specified entry.
      *

--- a/src/main/java/com/novell/ldapchai/provider/JLDAPProviderImpl.java
+++ b/src/main/java/com/novell/ldapchai/provider/JLDAPProviderImpl.java
@@ -231,6 +231,20 @@ public class JLDAPProviderImpl extends AbstractProvider implements ChaiProviderI
 
     @ChaiProvider.LdapOperation
     @ChaiProvider.ModifyOperation
+    public void renameEntry( String entryDN, String newRDN, String newParentDN)
+            throws ChaiOperationException, ChaiUnavailableException, IllegalStateException {
+        try
+        {
+            ldapConnection.rename(entryDN, newRDN, newParentDN, true);
+        }
+        catch ( LDAPException e )
+        {
+            throw ChaiOperationException.forErrorMessage( e.getLDAPErrorMessage() );
+        }
+    }
+
+    @ChaiProvider.LdapOperation
+    @ChaiProvider.ModifyOperation
     public void deleteEntry( final String entryDN )
             throws ChaiOperationException, ChaiUnavailableException, IllegalStateException
     {

--- a/src/main/java/com/novell/ldapchai/provider/JNDIProviderImpl.java
+++ b/src/main/java/com/novell/ldapchai/provider/JNDIProviderImpl.java
@@ -332,6 +332,30 @@ public class JNDIProviderImpl extends AbstractProvider implements ChaiProviderIm
         }
     }
 
+    @ChaiProvider.LdapOperation
+    @ChaiProvider.ModifyOperation
+    public void renameEntry(String entryDN, String newRDN, String newParentDN)
+            throws ChaiOperationException, ChaiUnavailableException, IllegalStateException {
+
+        activityPreCheck();
+        getInputValidator().renameEntry(entryDN, newRDN, newParentDN);
+
+        final LdapContext ldapConnection = getLdapConnection();
+        try
+        {
+            StringBuilder newDN = new StringBuilder( newRDN.length() + newParentDN.length() + 1 );
+            newDN.append( newRDN );
+            newDN.append( "," );
+            newDN.append( newParentDN );
+
+            ldapConnection.rename( entryDN, newDN.toString() );
+        }
+        catch ( NamingException e )
+        {
+            convertNamingException( e );
+        }
+    }
+
     @LdapOperation
     @ModifyOperation
     public final void deleteEntry( final String entryDN )

--- a/src/main/java/com/novell/ldapchai/provider/WatchdogWrapper.java
+++ b/src/main/java/com/novell/ldapchai/provider/WatchdogWrapper.java
@@ -164,6 +164,12 @@ class WatchdogWrapper implements ChaiProviderImplementor
     }
 
     @Override
+    public void renameEntry(String entryDN, String newRDN, String newParentDN)
+            throws ChaiOperationException, ChaiUnavailableException, IllegalStateException {
+        providerHolder.getProvider().renameEntry( entryDN, newRDN, newParentDN );
+    }
+
+    @Override
     public void deleteEntry( final String entryDN )
             throws ChaiOperationException, ChaiUnavailableException, IllegalStateException
     {


### PR DESCRIPTION
Allows renaming (and moving) entries; implemented only for the LDAP counterparts I have access to (namely `JLDAPProviderImpl` and `JNDIProviderImpl`).
