### PR TITLE
Fixing Uppercase Answers in Challenge Questions - 5002 Invalid

### DIFF
--- a/src/main/java/com/novell/ldapchai/cr/PBKDF2Answer.java
+++ b/src/main/java/com/novell/ldapchai/cr/PBKDF2Answer.java
@@ -86,7 +86,8 @@ class PBKDF2Answer implements Answer
             throw new IllegalArgumentException( "missing answerHash text" );
         }
 
-        this.hashedAnswer = hashValue( answer );
+        final String casedAnswer = this.caseInsensitive ? answer.toLowerCase() : answer;
+        this.hashedAnswer = hashValue( casedAnswer );
     }
 
 


### PR DESCRIPTION
This commit fixes a bug where secret answers are not validated if they contain an uppercase letter and the “case insensitive” option is enabled.

[This bug (Uppercase Answers in Challenge Questions - 5002 Invalid)](https://groups.google.com/g/pwm-general/c/0u4ABdhKL0g)  is happening in version v2.0.6 of the PWM project with version v0.8.5 of this library.

As detailed in my answer in the [PWM-General Google Group](https://groups.google.com/g/pwm-general/c/0u4ABdhKL0g), the comparison is performed by lower-casing the user's answer, but the original answer is not stored in lowercase. So it cannot work.

In this commit, secret answers are lower-cased when stored if the “case insensitive” option is enabled.