### PR TITLE
389 DS doesn't support groupmembership attribute

### DIFF
--- a/src/main/java/com/novell/ldapchai/impl/directoryServer389/entry/DirectoryServer389Group.java
+++ b/src/main/java/com/novell/ldapchai/impl/directoryServer389/entry/DirectoryServer389Group.java
@@ -19,7 +19,9 @@
 
 package com.novell.ldapchai.impl.directoryServer389.entry;
 
+import com.novell.ldapchai.ChaiConstant;
 import com.novell.ldapchai.ChaiGroup;
+import com.novell.ldapchai.ChaiUser;
 import com.novell.ldapchai.exception.ChaiOperationException;
 import com.novell.ldapchai.exception.ChaiUnavailableException;
 import com.novell.ldapchai.impl.AbstractChaiGroup;
@@ -37,5 +39,19 @@ class DirectoryServer389Group extends AbstractChaiGroup implements ChaiGroup
             throws ChaiOperationException, ChaiUnavailableException
     {
         return DirectoryServer389Entry.readGUIDImpl( this.getChaiProvider(), this.getEntryDN() );
+    }
+
+    @Override
+    public void addMember( final ChaiUser theUser )
+            throws ChaiUnavailableException, ChaiOperationException
+    {
+        this.addAttribute( ChaiConstant.ATTR_LDAP_MEMBER, theUser.getEntryDN() );
+    }
+
+    @Override
+    public void removeMember( final ChaiUser theUser )
+            throws ChaiUnavailableException, ChaiOperationException
+    {
+        this.deleteAttribute( ChaiConstant.ATTR_LDAP_MEMBER, theUser.getEntryDN() );
     }
 }

--- a/src/main/java/com/novell/ldapchai/impl/directoryServer389/entry/DirectoryServer389User.java
+++ b/src/main/java/com/novell/ldapchai/impl/directoryServer389/entry/DirectoryServer389User.java
@@ -19,6 +19,8 @@
 
 package com.novell.ldapchai.impl.directoryServer389.entry;
 
+import com.novell.ldapchai.ChaiConstant;
+import com.novell.ldapchai.ChaiGroup;
 import com.novell.ldapchai.ChaiUser;
 import com.novell.ldapchai.exception.ChaiOperationException;
 import com.novell.ldapchai.exception.ChaiPasswordPolicyException;
@@ -27,6 +29,9 @@ import com.novell.ldapchai.impl.AbstractChaiUser;
 import com.novell.ldapchai.provider.ChaiProvider;
 
 import java.time.Instant;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 class DirectoryServer389User extends AbstractChaiUser implements ChaiUser
 {
@@ -123,5 +128,32 @@ class DirectoryServer389User extends AbstractChaiUser implements ChaiUser
             throws ChaiOperationException, ChaiUnavailableException
     {
         return DirectoryServer389Entry.readGUIDImpl( this.getChaiProvider(), this.getEntryDN() );
+    }
+
+    @Override
+    public Set<ChaiGroup> getGroups()
+            throws ChaiOperationException, ChaiUnavailableException
+    {
+        final Set<ChaiGroup> returnGroups = new HashSet<>();
+        final Set<String> groups = this.readMultiStringAttribute( ChaiConstant.ATTR_LDAP_MEMBER_OF );
+        for ( final String group : groups )
+        {
+            returnGroups.add( chaiProvider.getEntryFactory().newChaiGroup( group ) );
+        }
+        return Collections.unmodifiableSet( returnGroups );
+    }
+
+    @Override
+    public void addGroupMembership( final ChaiGroup theGroup )
+            throws ChaiOperationException, ChaiUnavailableException
+    {
+        theGroup.addAttribute( ChaiConstant.ATTR_LDAP_MEMBER, this.getEntryDN() );
+    }
+
+    @Override
+    public void removeGroupMembership( final ChaiGroup theGroup )
+            throws ChaiOperationException, ChaiUnavailableException
+    {
+        theGroup.deleteAttribute( ChaiConstant.ATTR_LDAP_MEMBER, this.getEntryDN() );
     }
 }


### PR DESCRIPTION
Adding a user to a group in 389 Directory Server errors out with this response:
```
5015 ERROR_INTERNAL (unexpected error writing to ldap: javax.naming.directory.SchemaViolationException: [LDAP: error code 65 - attribute "groupmembership" not allowed
```
Since 389 DS only supports the `member` attribute, I overrode the`DirectoryServer389Group` and `DirectoryServer389User` classes to update that attribute. Additionally, I had to implement the `DirectoryServer389User.getGroups` method to use the `memberOf` attribute.